### PR TITLE
This fixes REGEXP so it does not break paths stored in `$filename`

### DIFF
--- a/fields/field.uniqueupload.php
+++ b/fields/field.uniqueupload.php
@@ -13,7 +13,7 @@
 		private function getUniqueFilename($filename) {
 			## since uniqid() is 13 bytes, the unique filename will be limited to ($crop+1+13) characters;
 			$crop  = '30';
-			return preg_replace("/(.*)(\.[^\.]+)/e", "substr('$1', 0, $crop).'-'.uniqid().'$2'", $filename);
+			return preg_replace("/([^\/]*)(\.[^\.]+)$/e", "substr('$1', 0, $crop).'-'.uniqid().'$2'", $filename);
 		}
 
 		public function checkPostFieldData($data, &$message, $entry_id = NULL) {


### PR DESCRIPTION
Fixed REGEXP so it replaces only base name of file instead of whole `$filename`. Upload field supports paths in filename, so "some/very/long/path/blah/with/many/sub/folders/test.jpg" would be changed to "some/very/long/path/with/many/-4de6b6de2e3a5.jpg" before the fix. Now it will be modified correctly to "some/very/long/path/blah/with/many/sub/folders/test-4de6b6e1c6a1e.jpg".
