### PR TITLE
Get Original Filename

### DIFF
--- a/fields/field.uniqueupload.php
+++ b/fields/field.uniqueupload.php
@@ -16,7 +16,7 @@
 			return preg_replace("/([^\/]*)(\.[^\.]+)$/e", "substr('$1', 0, $crop).'-'.uniqid().'$2'", $filename);
 		}
 
-		private function getOriginalFilename($filename) {
+		private static function getOriginalFilename($filename) {
 			var_dump($filename);
 			return preg_replace("/([^\/]*)(\-[a-f0-9]{13})(\.[^\.]+)$/", '$1$3', $filename);
 		}
@@ -35,6 +35,6 @@
 			parent::appendFormattedElement($wrapper, $data);
 			$field = $wrapper->getChildrenByName($this->get('element_name'));
 			if(!empty($field))
-				end($field)->appendChild(new XMLElement('original-filename', General::sanitize($this->getOriginalFilename(basename($data['file'])))));
+				end($field)->appendChild(new XMLElement('original-filename', General::sanitize(self::getOriginalFilename(basename($data['file'])))));
 		}
 	}


### PR DESCRIPTION
Hey Michael,

I've added some functionality to your unique upload field: The returned XML will now contain a new XML element:

```
<original-filename>test.jpg</original-filename>
```

It's basically guessing the old filename by removing the uniqueid() stuff via RegEx. It worked fine for a few files that I had uploaded and even when the file doesn't have any uniqueid stuff (a regular upload field ported to a unique uploadfield by fiddling in Symphony's tables).

Feel free to pull this into a separate branch if you want to give it some more time for testing. :-)
